### PR TITLE
[Needs rebase] Add mouseover and mouseout commands

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -129,6 +129,8 @@ Commands =
       "LinkHints.activateModeWithQueue",
       "LinkHints.activateModeToDownloadLink",
       "LinkHints.activateModeToOpenIncognito",
+      "LinkHints.activateModeToHover",
+      "LinkHints.unhoverLast",
       "goPrevious",
       "goNext",
       "nextFrame",
@@ -180,6 +182,8 @@ Commands =
     "Vomnibar.activateEditUrl",
     "Vomnibar.activateEditUrlInNewTab",
     "LinkHints.activateModeToOpenIncognito",
+    "LinkHints.activateModeToHover",
+    "LinkHints.unhoverLast",
     "goNext",
     "goPrevious",
     "Marks.activateCreateMode",
@@ -315,6 +319,8 @@ commandDescriptions =
   "LinkHints.activateModeWithQueue": ["Open multiple links in a new tab", { noRepeat: true }]
   "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window", { passCountToFunction: true }]
   "LinkHints.activateModeToDownloadLink": ["Download link url", { passCountToFunction: true }]
+  "LinkHints.activateModeToHover": ["Hover over a link", { passCountToFunction: true }]
+  "LinkHints.unhoverLast": ["Stop hovering at last location", { noRepeat: true }]
 
   enterFindMode: ["Enter find mode", { noRepeat: true }]
   performFind: ["Cycle forward to the next find match"]

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -17,6 +17,7 @@ OPEN_WITH_QUEUE = name: "queue"
 COPY_LINK_URL = name: "link"
 OPEN_INCOGNITO = name: "incognito"
 DOWNLOAD_LINK_URL = name: "download"
+HOVER = name: "hover"
 
 LinkHints =
   activateMode: (count = 1, mode = OPEN_IN_CURRENT_TAB) ->
@@ -34,6 +35,8 @@ LinkHints =
   activateModeWithQueue: -> @activateMode 1, OPEN_WITH_QUEUE
   activateModeToOpenIncognito: (count) -> @activateMode count, OPEN_INCOGNITO
   activateModeToDownloadLink: (count) -> @activateMode count, DOWNLOAD_LINK_URL
+  activateModeToHover: (count) -> @activateMode count, HOVER
+  unhoverLast: -> DomUtils.simulateUnhover()
 
 class LinkHintsMode
   hintMarkerContainingDiv: null
@@ -130,6 +133,10 @@ class LinkHintsMode
       @hintMode.setIndicator "Download link URL."
       @linkActivator = (link) ->
         DomUtils.simulateClick link, altKey: true, ctrlKey: false, metaKey: false
+    else if @mode is HOVER
+      @hintMode.setIndicator "Hover over a link."
+      @linkActivator = (link) ->
+        DomUtils.simulateHover link
     else # OPEN_IN_CURRENT_TAB
       @hintMode.setIndicator "Open link in current tab."
       @linkActivator = DomUtils.simulateClick.bind DomUtils

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -234,6 +234,8 @@ DomUtils =
           if element.selectionStart == 0 and element.selectionEnd == 0
             element.setSelectionRange element.value.length, element.value.length
 
+  simulateHover: (element, modifiers) -> @simulateMouseEvent "mouseover", element, modifiers
+
   simulateUnhover: (element, modifiers) -> @simulateMouseEvent "mouseout", element, modifiers
 
   simulateClick: (element, modifiers) ->


### PR DESCRIPTION
Adds `LinkHints.activateModeToHover` and `LinkHints.unhoverLast` to perform hovering. These are unbound by default.